### PR TITLE
fix duplicate executions of menubutton selections

### DIFF
--- a/controllers/main_page.py
+++ b/controllers/main_page.py
@@ -17,6 +17,7 @@ class MainPageController():
 
         self.config: config.Config = self.model.config.config
 
+        self.set_trace_listeners()
         self.fill_view(self.config)
 
     def _bind(self):
@@ -229,21 +230,23 @@ class MainPageController():
         self.frame.switch_refresh_mode_btn.config(command=self.change_automatic_refresh)
 
         self.frame.selected_genre_var.set(self.SELECTED_GENRE)
-        self.frame.selected_genre_var.trace_add("write", self.genres_menu_item_selected)
 
         for genre in self.config.displayed_music_genres:
             self.frame.genres_menu.add_radiobutton(label=genre, variable=self.frame.selected_genre_var)
 
         self.frame.selected_category_var.set(self.SELECTED_CATEGORY)
-        self.frame.selected_category_var.trace_add("write", self.categories_menu_item_selected)
 
         for category in self.config.displayed_music_categories:
             self.frame.categories_menu.add_radiobutton(label=category, variable=self.frame.selected_category_var)
 
         self.frame.selected_copy_move_var.set(self.CURRENT_COPY_MOVE_MODE)
-        self.frame.selected_copy_move_var.trace_add("write", self.copy_move_item_selected)
 
         self.frame.res_path_label_var.set(self.generate_move_path())
         self.frame.move_btn.config(command=self.handle_copy_move)
 
         self._bind()
+
+    def set_trace_listeners(self):
+        self.frame.selected_genre_var.trace_add("write", self.genres_menu_item_selected)
+        self.frame.selected_category_var.trace_add("write", self.categories_menu_item_selected)
+        self.frame.selected_copy_move_var.trace_add("write", self.copy_move_item_selected)


### PR DESCRIPTION
fixes #14 

issue was that each of the `trace_add` functions for the stringVars listening to writes (which get triggered whenever a menubutton is selected) were being executed twice for every `self.fill_view(config)` function in the `main_page` controller:

```python
        self.frame.selected_genre_var.trace_add("write", self.genres_menu_item_selected)
```

This happens whenever a new config model is submitted, and caused two event listeners for each `write` event in the strings to be created, thereby causing the duplicate executions of the selection for a menubutton item

This was fixed by creating a new function to handle the binding for the `write` event listeners to only happen once, independent of `self.fill_view(config)` executions whenever a new config is submitted:

```python
class MainPageController():
        self.set_trace_listeners()
        self.fill_view(self.config)
[...]
    def set_trace_listeners(self):
        self.frame.selected_genre_var.trace_add("write", self.genres_menu_item_selected)
        self.frame.selected_category_var.trace_add("write", self.categories_menu_item_selected)
        self.frame.selected_copy_move_var.trace_add("write", self.copy_move_item_selected)
```